### PR TITLE
Add action to release on pypi whenever there is a push to main

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,30 +1,86 @@
-name: Python package
+# This workflow will upload a Python Package to PyPI when a release is created
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
 
-on: [push, pull_request]
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
 
 jobs:
-  build:
-
+  release-build:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.10"]
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-        cache: 'pip'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install -e '.[dev]'
-    - name: Run linter
-      run: |
-        pylint -d all -e E0602 ./fastchat/
-    - name: Check formatting
-      run: |
-        black --check .
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Build release distributions
+        run: |
+          # NOTE: put your own distribution build steps here.
+          python -m pip install build
+          python -m build
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+  pypi-publish:
+    runs-on: ubuntu-latest
+    needs:
+      - release-build
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+
+    # Dedicated environments with protections for publishing are strongly recommended.
+    # For more information, see: https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#deployment-protection-rules
+    environment:
+      name: pypi
+      # OPTIONAL: uncomment and update to include your PyPI project URL in the deployment status:
+      # url: https://pypi.org/p/YOURPROJECT
+      #
+      # ALTERNATIVE: if your GitHub Release name is the PyPI project version string
+      # ALTERNATIVE: exactly, uncomment the following line instead:
+      # url: https://pypi.org/project/YOURPROJECT/${{ github.event.release.name }}
+
+    steps:
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+      - name: Check if version already exists on PyPI
+        run: |
+          PKG_NAME=$(grep -E '^name\s*=\s*' pyproject.toml | head -1 | sed 's/name\s*=\s*"\(.*\)"/\1/')
+          PKG_VERSION=$(grep -E '^version\s*=\s*' pyproject.toml | head -1 | sed 's/version\s*=\s*"\(.*\)"/\1/')
+          echo "Package name: $PKG_NAME"
+          echo "Package version: $PKG_VERSION"
+          EXISTS=$(curl -s https://pypi.org/pypi/$PKG_NAME/json | grep -F '"$PKG_VERSION"')
+          if [ -n "$EXISTS" ]; then
+            echo "Error: Version $PKG_VERSION of $PKG_NAME already exists on PyPI."
+            exit 1
+          fi
+
+      - name: Publish release distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
- This will create a pypi build whenever we push to main if the version in pyproject.toml isn't available on pypi. 
- Once this is approved I will add the pypi token to secrets so it can be used